### PR TITLE
tune Makefile to enable chinese pdf make (`make pdf`) with those chin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_imm/
+sav/
+ref/
+*.log
+*.gz

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ pdf: validate
 	$(Q)if [ ! -e $(BASEDIR) ]; then \
 	  mkdir -p $(BASEDIR); \
 	fi;
-	$(Q)fop -q  $(RENDERTMP)/lfs-pdf.fo $(BASEDIR)/$(PDF_OUTPUT) 2>fop.log
+	$(Q)fop -q -c stylesheets/fop.xconf $(RENDERTMP)/lfs-pdf.fo $(BASEDIR)/$(PDF_OUTPUT) 2>fop.log
 	@echo "$(BASEDIR)/$(PDF_OUTPUT) created"
 	@echo "fop.log created"
 

--- a/stylesheets/fop.xconf
+++ b/stylesheets/fop.xconf
@@ -102,7 +102,8 @@ the location of this file.
 <font-triplet name="WenQuanYi Micro Hei" style="italic" weight="bold"/> 
 </font> 
 
-<directory recursive="true">/usr/share/fonts/</directory> 
+<directory recursive="true">/usr/share/fonts/</directory>
+<directory recursive="true">~/.fonts/</directory>
 <auto-detect/> 
 
       </fonts>


### PR DESCRIPTION
…ese fonts;

对于拉回来的git文件，make pdf生成的pdf文件是中文字全变成`#`，所以这个PR中补上了fop.xconf命令行参数来解决该问题。
此外，首页的README应该加上足够的make说明，毕竟并非人人都能搞得懂fop,xslt等等一堆参数的。这个我就不越俎代庖了。
